### PR TITLE
fix (README.md): Markdown href link syntax

### DIFF
--- a/packages/fastui-prebuilt/README.md
+++ b/packages/fastui-prebuilt/README.md
@@ -1,3 +1,3 @@
 # FastUI pre-build
 
-Pre-built files for [FastUI](https://github.com/samuelcolvin/FastUI.
+Pre-built files for [FastUI](https://github.com/samuelcolvin/FastUI).


### PR DESCRIPTION
I fix the tiny error by correcting the markdown syntax.