### PR TITLE
Fix issue with missing required field default value in Navbar JSON schema.

### DIFF
--- a/demo/tests.py
+++ b/demo/tests.py
@@ -74,4 +74,3 @@ def test_doc():
     title = html_content[title_start:title_end]
     assert title == 'FastAPI - Swagger UI'
     assert r.headers.get('content-type') == 'text/html; charset=utf-8'
-

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -69,8 +69,8 @@ def test_doc():
     r = client.get('/docs')
     assert r.status_code == 200, r.text
     html_content = r.text
-    title_start = html_content.find("<title>") + len("<title>")
-    title_end = html_content.find("</title>")
+    title_start = html_content.find('<title>') + len('<title>')
+    title_end = html_content.find('</title>')
     title = html_content[title_start:title_end]
     assert title == 'FastAPI - Swagger UI'
     assert r.headers.get('content-type') == 'text/html; charset=utf-8'

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -64,14 +64,3 @@ def test_menu_links(url: str):
 
 
 # TODO tests for forms, including submission
-
-
-def test_doc():
-    r = client.get('/docs')
-    assert r.status_code == 200, r.text
-    html_content = r.text
-    title_start = html_content.find('<title>') + len('<title>')
-    title_end = html_content.find('</title>')
-    title = html_content[title_start:title_end]
-    assert title == 'FastAPI - Swagger UI'
-    assert r.headers.get('content-type') == 'text/html; charset=utf-8'

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -64,7 +64,7 @@ def test_menu_links(url: str):
 
 
 # TODO tests for forms, including submission
-    
+
 def test_doc():
     r = client.get('/docs')
     assert r.status_code == 200, r.text

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -65,6 +65,7 @@ def test_menu_links(url: str):
 
 # TODO tests for forms, including submission
 
+
 def test_doc():
     r = client.get('/docs')
     assert r.status_code == 200, r.text

--- a/demo/tests.py
+++ b/demo/tests.py
@@ -64,3 +64,14 @@ def test_menu_links(url: str):
 
 
 # TODO tests for forms, including submission
+    
+def test_doc():
+    r = client.get('/docs')
+    assert r.status_code == 200, r.text
+    html_content = r.text
+    title_start = html_content.find("<title>") + len("<title>")
+    title_end = html_content.find("</title>")
+    title = html_content[title_start:title_end]
+    assert title == 'FastAPI - Swagger UI'
+    assert r.headers.get('content-type') == 'text/html; charset=utf-8'
+

--- a/src/python-fastui/fastui/components/__init__.py
+++ b/src/python-fastui/fastui/components/__init__.py
@@ -185,7 +185,7 @@ class Navbar(_p.BaseModel, extra='forbid'):
     ) -> _t.Any:
         # until https://github.com/pydantic/pydantic/issues/8413 is fixed
         json_schema = handler(core_schema)
-        json_schema['required'].append('links')
+        json_schema.setdefault('required', []).append('links')
         return json_schema
 
 

--- a/src/python-fastui/tests/test_json_schema.py
+++ b/src/python-fastui/tests/test_json_schema.py
@@ -1,6 +1,8 @@
 from dirty_equals import IsPartialDict
-from fastui import FastUI
+from fastapi import FastAPI
+from fastui import FastUI, components
 from fastui.generate_typescript import generate_json_schema
+from httpx import AsyncClient
 
 
 async def test_json_schema():
@@ -12,3 +14,25 @@ async def test_json_schema():
         'type': 'array',
     }
     # TODO test more specific cases
+
+
+async def test_openapi():
+    app = FastAPI()
+
+    @app.get('/api/', response_model=FastUI, response_model_exclude_none=True)
+    def test_endpoint():
+        return [components.Text(text='hello')]
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        r = await client.get('/openapi.json')
+        assert r.status_code == 200
+        assert r.headers['content-type'] == 'application/json'
+        assert r.json() == {
+            'openapi': '3.1.0',
+            'info': {
+                'title': 'FastAPI',
+                'version': '0.1.0',
+            },
+            'paths': IsPartialDict(),
+            'components': IsPartialDict(),
+        }


### PR DESCRIPTION
This is fix for #129 Demo code /docs Fetch error Internal Server Error /openapi.json 

**Issue:**
when generating openapi schema for fastui component, for navibar component, default value for key = "required" is missing 
**Solution:**
Add default value when generating schema

Note:
In docs some api point loading still very slow due to known issue: see https://github.com/pydantic/FastUI/issues/58