### PR TITLE
fix: support finding initial value from a list of values

### DIFF
--- a/src/npm-fastui/src/components/FormField.tsx
+++ b/src/npm-fastui/src/components/FormField.tsx
@@ -147,6 +147,12 @@ export const FormFieldSelectReactComp: FC<FormFieldSelectProps> = (props) => {
 
   const className = useClassName(props)
   const classNameSelectReact = useClassName(props, { el: 'select-react' })
+  let value
+  if (Array.isArray(initial)) {
+    value = findDefaultArray(options, initial)
+  } else {
+    value = findDefault(options, initial)
+  }
 
   const reactSelectOnChanged = () => {
     // TODO this is a hack to wait for the input to be updated, can we do better?
@@ -164,7 +170,7 @@ export const FormFieldSelectReactComp: FC<FormFieldSelectProps> = (props) => {
         className={classNameSelectReact}
         isMulti={multiple ?? false}
         isClearable
-        defaultValue={findDefault(options, initial)}
+        defaultValue={value}
         name={name}
         required={required}
         isDisabled={locked}
@@ -191,6 +197,11 @@ const SelectOptionComp: FC<{ option: SelectOption | SelectGroup }> = ({ option }
   } else {
     return <option value={option.value}>{option.label}</option>
   }
+}
+
+function findDefaultArray(options: SelectOptions, value: string[]): SelectOption[] {
+  const foundValues = value.map((v) => findDefault(options, v))
+  return foundValues.filter((v) => v) as SelectOption[]
 }
 
 function findDefault(options: SelectOptions, value?: string): SelectOption | undefined {

--- a/src/npm-fastui/src/models.d.ts
+++ b/src/npm-fastui/src/models.d.ts
@@ -358,7 +358,7 @@ export interface FormFieldSelect {
   className?: ClassName
   options: SelectOptions
   multiple?: boolean
-  initial?: string
+  initial?: string[] | string
   vanilla?: boolean
   placeholder?: string
   type: 'FormFieldSelect'

--- a/src/python-fastui/fastui/components/forms.py
+++ b/src/python-fastui/fastui/components/forms.py
@@ -49,7 +49,7 @@ class FormFieldFile(BaseFormField):
 class FormFieldSelect(BaseFormField):
     options: forms.SelectOptions
     multiple: _t.Union[bool, None] = None
-    initial: _t.Union[str, None] = None
+    initial: _t.Union[list[str], str, None] = None
     vanilla: _t.Union[bool, None] = None
     placeholder: _t.Union[str, None] = None
     type: _t.Literal['FormFieldSelect'] = 'FormFieldSelect'

--- a/src/python-fastui/fastui/components/forms.py
+++ b/src/python-fastui/fastui/components/forms.py
@@ -49,7 +49,7 @@ class FormFieldFile(BaseFormField):
 class FormFieldSelect(BaseFormField):
     options: forms.SelectOptions
     multiple: _t.Union[bool, None] = None
-    initial: _t.Union[list[str], str, None] = None
+    initial: _t.Union[_t.List[str], str, None] = None
     vanilla: _t.Union[bool, None] = None
     placeholder: _t.Union[str, None] = None
     type: _t.Literal['FormFieldSelect'] = 'FormFieldSelect'


### PR DESCRIPTION
Hi! Awesome job on yet another repository! 👏

Before this
passing a list to `ModelForm(initial={"some_field": SOME_LIST})` didn't work.
See https://github.com/pydantic/FastUI/issues/91


Mini example (not compilable):

```python
from fastui import components as c
from pydantic import BaseModel


@router.get("/some-api-path",  response_model=FastUI,  response_model_exclude_none=True)
def some_route() -> list[c.AnyComponent]:
  return [c.ModelForm(
    model=SelectForm,
    submit_url="./some-submit-url",
    initial={"tools": [MyEnum.stick]},
  )]


class MyEnum(str, Enum):
  hammer = "hammer"
  stick = "stick"


class SelectForm(BaseModel):
  tools: list[MyEnum] = Field(default_factory=list)

```