### PR TITLE
add `autocomplete` to `textarea` and `select`

### DIFF
--- a/src/npm-fastui/src/components/FormField.tsx
+++ b/src/npm-fastui/src/components/FormField.tsx
@@ -51,7 +51,7 @@ interface FormFieldTextareaProps extends FormFieldTextarea {
 }
 
 export const FormFieldTextareaComp: FC<FormFieldTextareaProps> = (props) => {
-  const { name, placeholder, required, locked, rows, cols , autocomplete} = props
+  const { name, placeholder, required, locked, rows, cols, autocomplete } = props
   return (
     <div className={useClassName(props)}>
       <Label {...props} />

--- a/src/npm-fastui/src/components/FormField.tsx
+++ b/src/npm-fastui/src/components/FormField.tsx
@@ -51,7 +51,7 @@ interface FormFieldTextareaProps extends FormFieldTextarea {
 }
 
 export const FormFieldTextareaComp: FC<FormFieldTextareaProps> = (props) => {
-  const { name, placeholder, required, locked, rows, cols } = props
+  const { name, placeholder, required, locked, rows, cols , autocomplete} = props
   return (
     <div className={useClassName(props)}>
       <Label {...props} />
@@ -66,6 +66,7 @@ export const FormFieldTextareaComp: FC<FormFieldTextareaProps> = (props) => {
         disabled={locked}
         placeholder={placeholder}
         aria-describedby={descId(props)}
+        autoComplete={autocomplete}
       />
       <ErrorDescription {...props} />
     </div>
@@ -141,7 +142,7 @@ export const FormFieldSelectComp: FC<FormFieldSelectProps> = (props) => {
 }
 
 export const FormFieldSelectVanillaComp: FC<FormFieldSelectProps> = (props) => {
-  const { name, required, locked, options, multiple, initial, placeholder, onChange } = props
+  const { name, required, locked, options, multiple, initial, placeholder, onChange, autocomplete } = props
 
   const className = useClassName(props)
   const classNameSelect = useClassName(props, { el: 'select' })
@@ -159,6 +160,7 @@ export const FormFieldSelectVanillaComp: FC<FormFieldSelectProps> = (props) => {
         aria-describedby={descId(props)}
         placeholder={placeholder}
         onChange={() => onChange && onChange()}
+        autoComplete={autocomplete}
       >
         {multiple ? null : <option></option>}
         {options.map((option, i) => (

--- a/src/npm-fastui/src/models.d.ts
+++ b/src/npm-fastui/src/models.d.ts
@@ -431,7 +431,6 @@ export interface FormFieldSelectSearch {
   initial?: SelectOption
   debounce?: number
   placeholder?: string
-  autocomplete?: string
   type: 'FormFieldSelectSearch'
 }
 export interface ModelForm {

--- a/src/npm-fastui/src/models.d.ts
+++ b/src/npm-fastui/src/models.d.ts
@@ -363,6 +363,7 @@ export interface FormFieldTextarea {
   cols?: number
   initial?: string
   placeholder?: string
+  autocomplete?: string
   type: 'FormFieldTextarea'
 }
 export interface FormFieldBoolean {
@@ -405,6 +406,7 @@ export interface FormFieldSelect {
   initial?: string[] | string
   vanilla?: boolean
   placeholder?: string
+  autocomplete?: string
   type: 'FormFieldSelect'
 }
 export interface SelectOption {
@@ -429,6 +431,7 @@ export interface FormFieldSelectSearch {
   initial?: SelectOption
   debounce?: number
   placeholder?: string
+  autocomplete?: string
   type: 'FormFieldSelectSearch'
 }
 export interface ModelForm {

--- a/src/python-fastui/fastui/components/forms.py
+++ b/src/python-fastui/fastui/components/forms.py
@@ -40,6 +40,7 @@ class FormFieldTextarea(BaseFormField):
     cols: _t.Union[int, None] = None
     initial: _t.Union[str, None] = None
     placeholder: _t.Union[str, None] = None
+    autocomplete: _t.Union[str, None] = None
     type: _t.Literal['FormFieldTextarea'] = 'FormFieldTextarea'
 
 
@@ -61,6 +62,7 @@ class FormFieldSelect(BaseFormField):
     initial: _t.Union[_t.List[str], str, None] = None
     vanilla: _t.Union[bool, None] = None
     placeholder: _t.Union[str, None] = None
+    autocomplete: _t.Union[str, None] = None
     type: _t.Literal['FormFieldSelect'] = 'FormFieldSelect'
 
 
@@ -71,6 +73,7 @@ class FormFieldSelectSearch(BaseFormField):
     # time in ms to debounce requests by, defaults to 300ms
     debounce: _t.Union[int, None] = None
     placeholder: _t.Union[str, None] = None
+    autocomplete: _t.Union[str, None] = None
     type: _t.Literal['FormFieldSelectSearch'] = 'FormFieldSelectSearch'
 
 

--- a/src/python-fastui/fastui/components/forms.py
+++ b/src/python-fastui/fastui/components/forms.py
@@ -73,7 +73,6 @@ class FormFieldSelectSearch(BaseFormField):
     # time in ms to debounce requests by, defaults to 300ms
     debounce: _t.Union[int, None] = None
     placeholder: _t.Union[str, None] = None
-    autocomplete: _t.Union[str, None] = None
     type: _t.Literal['FormFieldSelectSearch'] = 'FormFieldSelectSearch'
 
 

--- a/src/python-fastui/fastui/json_schema.py
+++ b/src/python-fastui/fastui/json_schema.py
@@ -282,7 +282,6 @@ def special_string_field(
                 multiple=multiple,
                 initial=schema.get('initial'),
                 description=schema.get('description'),
-                autocomplete=schema.get('autocomplete'),
             )
 
 

--- a/src/python-fastui/fastui/json_schema.py
+++ b/src/python-fastui/fastui/json_schema.py
@@ -257,6 +257,7 @@ def special_string_field(
                 placeholder=schema.get('placeholder'),
                 initial=schema.get('initial'),
                 description=schema.get('description'),
+                autocomplete=schema.get('autocomplete'),
             )
         elif enum := schema.get('enum'):
             enum_labels = schema.get('enum_labels', {})
@@ -269,6 +270,7 @@ def special_string_field(
                 options=[SelectOption(value=v, label=enum_labels.get(v) or as_title(v)) for v in enum],
                 initial=schema.get('default'),
                 description=schema.get('description'),
+                autocomplete=schema.get('autocomplete'),
             )
         elif search_url := schema.get('search_url'):
             return FormFieldSelectSearch(
@@ -280,6 +282,7 @@ def special_string_field(
                 multiple=multiple,
                 initial=schema.get('initial'),
                 description=schema.get('description'),
+                autocomplete=schema.get('autocomplete'),
             )
 
 


### PR DESCRIPTION
couldn't add it to the `Select` from `react-select` as it seems it doesn't support it - i get the following error message:
```
Property autoComplete does not exist on type
IntrinsicAttributes & Omit<PublicBaseSelectProps<unknown, boolean, GroupBase<unknown>>, StateManagedPropKeys> & Partial<...> & StateManagerAdditionalProps<...> & RefAttributes<...>
```
not sure what to do for that one.

should close https://github.com/pydantic/FastUI/issues/92