### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
         patterns:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
Auto-generates pull requests like math-a3k/tradero#30 to keep GitHub Actions up to date which should remove warnings like at the bottom right of https://github.com/pydantic/FastUI/actions/runs/8003132720
* https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem