### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/src/npm-fastui-bootstrap/package.json
+++ b/src/npm-fastui-bootstrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pydantic/fastui-bootstrap",
   "version": "0.0.22",
-  "description": "Boostrap renderer for FastUI",
+  "description": "Bootstrap renderer for FastUI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Samuel Colvin",

--- a/src/npm-fastui/src/events.ts
+++ b/src/npm-fastui/src/events.ts
@@ -64,7 +64,7 @@ export function useFireEvent(): { fireEvent: (event?: AnyEvent) => void } {
     }
   }
 
-  // fireEventImpl is recursive, but it doens't make sense for fireEvent to have fireEventImpl as a dep
+  // fireEventImpl is recursive, but it doesn't make sense for fireEvent to have fireEventImpl as a dep
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const fireEvent = useCallback(fireEventImpl, [location])
 


### PR DESCRIPTION
https://pypi.org/project/codespell
```diff
-  "description": "Boostrap renderer for FastUI",
+  "description": "Bootstrap renderer for FastUI",
                      ^

-  // fireEventImpl is recursive, but it doens't make sense for fireEvent to have fireEventImpl as a dep
+  // fireEventImpl is recursive, but it doesn't make sense for fireEvent to have fireEventImpl as a dep
                                            ^
```