### PR TITLE
Fix display `0` on `DisplayLookup`

### DIFF
--- a/src/npm-fastui/src/components/details.tsx
+++ b/src/npm-fastui/src/components/details.tsx
@@ -23,7 +23,7 @@ const FieldDetail: FC<{ props: Details; fieldDisplay: DisplayLookupProps }> = ({
     <>
       <dt className={useClassName(props, { el: 'dt' })}>{title ?? asTitle(field)}</dt>
       <dd className={useClassName(props, { el: 'dd' })}>
-        <DisplayComp type="Display" onClick={renderedOnClick} value={value || null} {...rest} />
+        <DisplayComp type="Display" onClick={renderedOnClick} value={value !== undefined ? value : null} {...rest} />
       </dd>
     </>
   )

--- a/src/npm-fastui/src/components/table.tsx
+++ b/src/npm-fastui/src/components/table.tsx
@@ -44,7 +44,7 @@ const Cell: FC<{ row: DataModel; column: DisplayLookupProps }> = ({ row, column 
   const renderedOnClick = renderEvent(onClick, row)
   return (
     <td>
-      <DisplayComp type="Display" onClick={renderedOnClick} value={value || null} {...rest} />
+      <DisplayComp type="Display" onClick={renderedOnClick} value={value !== undefined ? value : null} {...rest} />
     </td>
   )
 }


### PR DESCRIPTION
This is the old view that shows `-` instead of `0`.
<img width="654" alt="image" src="https://github.com/pydantic/FastUI/assets/3122442/fb81d0fe-e27e-49f6-ab49-d9faf302bf99">

By this change it will only shows `-` for `undefined`
