### PR TITLE
Add docs link to demo, disable typescript docs for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,17 @@ jobs:
         with:
           python-version: '3.11'
 
+      # note: PPPR_TOKEN is not available on PRs sourced from forks, but the necessary
+      # dependencies are also listed in docs.txt :)
       - name: install
         run: |
           pip install --upgrade pip
+          pip install --extra-index-url https://pydantic:${PPPR_TOKEN}@pppr.pydantic.dev/simple/ mkdocs-material mkdocstrings-python
           pip install -r requirements/docs.txt
-          pip install --extra-index-url https://pydantic:${PPPR_TOKEN}@pppr.pydantic.dev/simple/ mkdocs-material mkdocstrings-python griffe-typedoc mkdocstrings-typescript
-          npm install
-          npm install -g typedoc
+        # note -- we can use these in the future when mkdocstrings-typescript and griffe-typedoc beocome publicly available
+        # pip install --extra-index-url https://pydantic:${PPPR_TOKEN}@pppr.pydantic.dev/simple/ mkdocs-material mkdocstrings-python griffe-typedoc mkdocstrings-typescript
+        # npm install
+        # npm install -g typedoc
         env:
           PPPR_TOKEN: ${{ secrets.PPPR_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 	pre-commit install
 
 
-.PHONY install-docs
+.PHONY: install-docs
 install-docs:
 	pip install -r requirements/docs.txt
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ install:
 	pip install -e $(path)
 	pre-commit install
 
+
+.PHONY install-docs
+install-docs:
+	pip install -r requirements/docs.txt
+
+# note -- mkdocstrings-typescript and griffe-typedoc are not yet publicly available
+# but the following can be added above the pip install -r requirements/docs.txt line in the future
+# pip install mkdocstrings-python mkdocstrings-typescript griffe-typedoc
+
 .PHONY: update-lockfiles
 update-lockfiles:
 	@echo "Updating requirements files using pip-compile"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FastUI
 
+Find the documentation [here](https://docs.pydantic.dev/fastui/).
+
 [![CI](https://github.com/pydantic/FastUI/actions/workflows/ci.yml/badge.svg)](https://github.com/pydantic/FastUI/actions?query=event%3Apush+branch%3Amain+workflow%3ACI)
 [![pypi](https://img.shields.io/pypi/v/fastui.svg)](https://pypi.python.org/pypi/fastui)
 [![versions](https://img.shields.io/pypi/pyversions/fastui.svg)](https://github.com/pydantic/FastUI)

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -5,9 +5,11 @@ set -x
 
 python3 -V
 
+python3 -m pip install --extra-index-url https://pydantic:${PPPR_TOKEN}@pppr.pydantic.dev/simple/ mkdocs-material mkdocstrings-python
 python3 -m pip install -r ./requirements/docs.txt
-pip install --extra-index-url https://pydantic:$PPPR_TOKEN@pppr.pydantic.dev/simple/ mkdocs-material mkdocstrings-python griffe-typedoc mkdocstrings-typescript
-npm install
-npm install -g typedoc
+# note -- we can use these in the future when mkdocstrings-typescript and griffe-typedoc beocome publicly available
+# python3 -m pip install --extra-index-url https://pydantic:$PPPR_TOKEN@pppr.pydantic.dev/simple/ mkdocs-material mkdocstrings-python griffe-typedoc mkdocstrings-typescript
+# npm install
+# npm install -g typedoc
 
 python3 -m mkdocs build

--- a/demo/main.py
+++ b/demo/main.py
@@ -16,6 +16,8 @@ def api_index() -> list[AnyComponent]:
 This site provides a demo of [FastUI](https://github.com/pydantic/FastUI), the code for the demo
 is [here](https://github.com/pydantic/FastUI/tree/main/demo).
 
+You can find the documentation for FastUI [here](https://docs.pydantic.dev/fastui/).
+
 The following components are demonstrated:
 
 * `Markdown` — that's me :-)

--- a/docs/api/typescript_components.md
+++ b/docs/api/typescript_components.md
@@ -3,5 +3,7 @@
 !!! warning "🚧 Work in Progress"
     This page is a work in progress.
 
-::: @pydantic/fastui
-    handler: typescript
+<!-- Note -- we will enable this in the future when mkdocstrings-typescript and griffe-typedoc
+Have publicly available options -->
+<!-- ::: @pydantic/fastui
+    handler: typescript -->


### PR DESCRIPTION
Also makes local builds more friendly for developers who don't have insiders access to mkdocstrings :).