### PR TITLE
Allow nesting subcomponents like Images inside of Tables, Details, etc.

### DIFF
--- a/src/npm-fastui/src/components/display.tsx
+++ b/src/npm-fastui/src/components/display.tsx
@@ -1,9 +1,11 @@
 import { FC } from 'react'
 
-import type { AnyEvent, DisplayMode, Display, JsonData } from '../models'
+import type { AnyEvent, DisplayMode, Display, JsonData, FastProps } from '../models'
 
 import { useCustomRender } from '../hooks/config'
 import { unreachable, asTitle } from '../tools'
+
+import { AnyComp } from '.'
 
 import { JsonComp } from './Json'
 import { LinkRender } from './link'
@@ -26,6 +28,28 @@ export const DisplayComp: FC<Display> = (props) => {
   }
 }
 
+// todo: this list should probably be defined in the models file
+const nestableSubcomponents = [
+  'Text',
+  'Paragraph',
+  'Div',
+  'Heading',
+  'Markdown',
+  'Code',
+  'Json',
+  'Button',
+  'Link',
+  'LinkList',
+  'ServerLoad',
+  'Image',
+  'Iframe',
+  'Video',
+  'Spinner',
+  'Custom',
+  'Table',
+  'Details',
+]
+
 const DisplayRender: FC<Display> = (props) => {
   const mode = props.mode ?? 'auto'
   const value = props.value ?? null
@@ -34,7 +58,11 @@ const DisplayRender: FC<Display> = (props) => {
   } else if (Array.isArray(value)) {
     return <DisplayArray mode={mode} value={value} />
   } else if (typeof value === 'object' && value !== null) {
-    return <DisplayObject mode={mode} value={value} />
+    if (value.type !== null && typeof value.type === 'string' && nestableSubcomponents.includes(value.type)) {
+      return <AnyComp {...(value as unknown as FastProps)} />
+    } else {
+      return <DisplayObject mode={mode} value={value} />
+    }
   } else {
     return <DisplayPrimitive mode={mode} value={value} />
   }


### PR DESCRIPTION
This PR allows FastUI components to be used as the values of DataModel's passed into Table and Details components.  This means that one can have a column in a table that is an Image, Button, etc.

For example, let's say I have an object with a name and an image.

```python
from pydantic import BaseCase
import fastui.components as c

class MyType(BaseClass):
  name: str
  # let's make icon a fastui `Image` component type
  icon: c.Image

# create an instance
my_object = MyType(name="meowzer", icon=c.Image(src="image.png"))

# try to render it inside of a `Details` component.
c.Page(
  components=[
    c.Details(data=my_object)
  ]
)
```

Before this PR:
| | |
| -- | -- |
| name | meowzer |
| icon | src: image.png, type: Image, |

After this PR:

| | |
| -- | -- |
| name | meowzer |
| icon | ![image](https://github.com/pydantic/FastUI/assets/381432/2d28ef07-9f6a-4a76-9500-271d76146269) |

FYI: @samuelcolvin @sydney-runkle 

Note: Implements enhancement request #293

fix #293
fix #267