### PR TITLE
Support default_factory in form fields.

### DIFF
--- a/demo/forms.py
+++ b/demo/forms.py
@@ -2,7 +2,7 @@ from __future__ import annotations as _annotations
 
 import enum
 from collections import defaultdict
-from datetime import date
+from datetime import date, timedelta
 from typing import Annotated, Literal, TypeAlias
 
 from fastapi import APIRouter, Request, UploadFile
@@ -160,6 +160,7 @@ class BigModel(BaseModel):
         Annotated[int, Field(description='X Coordinate')],
         Annotated[int, Field(description='Y Coordinate')],
     ]
+    start_data: date = Field(default_factory=lambda: date.today() + timedelta(days=1), title='Start Date')
 
     @field_validator('name')
     def name_validator(cls, v: str | None) -> str:

--- a/src/python-fastui/tests/test_forms.py
+++ b/src/python-fastui/tests/test_forms.py
@@ -1,9 +1,11 @@
 import enum
 from contextlib import asynccontextmanager
+from datetime import date
 from io import BytesIO
 from typing import List, Tuple, Union
 
 import pytest
+from dirty_equals import IsDate
 from fastapi import HTTPException
 from fastui import components
 from fastui.forms import FormFile, Textarea, fastui_form
@@ -517,6 +519,31 @@ def test_form_description_leakage():
                 'title': ['Select Multiple'],
                 'type': 'FormFieldSelect',
             },
+        ],
+        'method': 'POST',
+        'submitUrl': '/foobar/',
+        'type': 'ModelForm',
+    }
+
+
+class FormFieldsDefaultFactory(BaseModel):
+    start_date: date = Field(title='Start Date', default_factory=lambda: date.today())
+
+
+def test_form_fields_default_factory():
+    m = components.ModelForm(model=FormFieldsDefaultFactory, submit_url='/foobar/')
+
+    assert m.model_dump(by_alias=True, exclude_none=True) == {
+        'formFields': [
+            {
+                'htmlType': 'date',
+                'initial': IsDate(approx=date.today(), iso_string=True),
+                'locked': False,
+                'name': 'start_date',
+                'required': False,
+                'title': ['Start Date'],
+                'type': 'FormFieldInput',
+            }
         ],
         'method': 'POST',
         'submitUrl': '/foobar/',


### PR DESCRIPTION
Fixes #263.

This PR leads to some code duplication, since Pydantic does not expose api to include default_factory into JSON schema, see https://github.com/pydantic/pydantic/blob/main/pydantic/json_schema.py#L1046. Let me know if there is a better way.
