### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/demo/auth_user.py
+++ b/demo/auth_user.py
@@ -40,8 +40,8 @@ class User:
             payload = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
         except jwt.ExpiredSignatureError:
             return None
-        except jwt.DecodeError:
-            raise HTTPException(status_code=401, detail='Invalid token')
+        except jwt.DecodeError as exc:
+            raise HTTPException(status_code=401, detail='Invalid token') from exc
         else:
             # existing token might not have 'exp' field
             payload.pop('exp', None)

--- a/src/python-fastui/fastui/components/tables.py
+++ b/src/python-fastui/fastui/components/tables.py
@@ -40,8 +40,8 @@ class Table(BaseModel, extra='forbid'):
         else:
             try:
                 data_model_type = type(self.data[0])
-            except IndexError:
-                raise ValueError('Cannot infer model from empty data, please set `Table(..., model=MyModel)`')
+            except IndexError as exc:
+                raise ValueError('Cannot infer model from empty data, please set `Table(..., model=MyModel)`)') from exc
 
         all_model_fields = {**data_model_type.model_fields, **data_model_type.model_computed_fields}
         if self.columns is None:


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.