### PR TITLE
Show invalid message for select fields

### DIFF
--- a/src/npm-fastui-bootstrap/src/index.tsx
+++ b/src/npm-fastui-bootstrap/src/index.tsx
@@ -84,15 +84,14 @@ export const classNameGenerator: ClassNameGenerator = ({
       switch (subElement) {
         case 'textarea':
         case 'input':
+        case 'select-react':
           return {
-            'form-control': type !== 'FormFieldBoolean',
+            'form-control': !['FormFieldBoolean', 'FormFieldSelect'].includes(type),
             'is-invalid': props.error != null,
             'form-check-input': type === 'FormFieldBoolean',
           }
         case 'select':
           return 'form-select'
-        case 'select-react':
-          return ''
         case 'label':
           if (props.displayMode === 'inline') {
             return 'visually-hidden'


### PR DESCRIPTION
Fixes https://github.com/pydantic/FastUI/issues/270

Before:
<img width="457" alt="Screenshot 2024-10-17 at 15 23 44" src="https://github.com/user-attachments/assets/57eecf26-c58f-468d-a65b-16e24554c5d8">


After:
<img width="440" alt="Screenshot 2024-10-17 at 15 11 29" src="https://github.com/user-attachments/assets/8f2f5f3e-638f-447b-8bfe-e8fde20f46ae">

For this 422 error:
```json
{
    "detail": {
        "form": [
            {
                "type": "text",
                "loc": [
                    "text_field"
                ],
                "msg": "Text field error"
            },
            {
                "type": "select",
                "loc": [
                    "select_single"
                ],
                "msg": "Select field error"
            }
        ]
    }
}
```

We could go further and display the border in red like the text field, but that doesn't seem trivial.