### PR TITLE
Fix `GoToEvent` query param

### DIFF
--- a/src/npm-fastui/src/events.ts
+++ b/src/npm-fastui/src/events.ts
@@ -38,10 +38,14 @@ export function useFireEvent(): { fireEvent: (event?: AnyEvent) => void } {
       }
       case 'go-to':
         if (event.url) {
+          let url = event.url
+          if (event.query) {
+            url += '?' + new URLSearchParams(event.query as Record<string, string>).toString()
+          }
           if (event.target) {
-            window.open(event.url, event.target)
+            window.open(url, event.target)
           } else {
-            location.goto(event.url)
+            location.goto(url)
           }
         }
         if (event.query) {


### PR DESCRIPTION
Fixes https://github.com/pydantic/FastUI/issues/188

Not proud of `as Record<string, string>` but it's the best solution I found to keep ts happy even though `URLSearchParams` works fine with numbers 🤷:

![Screenshot 2024-10-23 at 14 52 03](https://github.com/user-attachments/assets/b0b50292-7496-45e3-983d-f2c0e65f3582)

