### PR TITLE
Add Radio and Toggle form fields (closes #160)

### DIFF
--- a/src/npm-fastui-bootstrap/src/Radio.tsx
+++ b/src/npm-fastui-bootstrap/src/Radio.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react'
+import { components, models } from 'fastui'
+
+/**
+ * Bootstrap-flavoured wrapper around the core `FormFieldRadioComp`.
+ *
+ * The radio button group itself is rendered by the core npm-fastui package; the
+ * styling for Bootstrap is supplied via the `classNameGenerator` in this
+ * package's `index.tsx`. This wrapper exists so consumers can plug a Radio in
+ * via `customRender` (or import it directly) without having to reach into
+ * `fastui/components`. Matches the file layout of `modal.tsx` / `navbar.tsx`.
+ */
+export const Radio: FC<models.FormFieldRadio> = (props) => {
+  return <components.FormFieldRadioComp {...props} />
+}

--- a/src/npm-fastui-bootstrap/src/Toggle.tsx
+++ b/src/npm-fastui-bootstrap/src/Toggle.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react'
+import { components, models } from 'fastui'
+
+/**
+ * Bootstrap-flavoured wrapper around the core `FormFieldToggleComp`.
+ *
+ * The toggle (on/off switch) itself is rendered by the core npm-fastui package;
+ * Bootstrap styling is supplied via the `classNameGenerator` in this package's
+ * `index.tsx`. The wrapper exists so consumers can plug a Toggle in via
+ * `customRender` (or import it directly) without having to reach into
+ * `fastui/components`. Matches the file layout of `modal.tsx` / `navbar.tsx`.
+ */
+export const Toggle: FC<models.FormFieldToggle> = (props) => {
+  return <components.FormFieldToggleComp {...props} />
+}

--- a/src/npm-fastui-bootstrap/src/index.tsx
+++ b/src/npm-fastui-bootstrap/src/index.tsx
@@ -78,6 +78,8 @@ export const classNameGenerator: ClassNameGenerator = ({
     case 'FormFieldInput':
     case 'FormFieldTextarea':
     case 'FormFieldBoolean':
+    case 'FormFieldToggle':
+    case 'FormFieldRadio':
     case 'FormFieldSelect':
     case 'FormFieldSelectSearch':
     case 'FormFieldFile':
@@ -85,9 +87,9 @@ export const classNameGenerator: ClassNameGenerator = ({
         case 'textarea':
         case 'input':
           return {
-            'form-control': type !== 'FormFieldBoolean',
+            'form-control': type !== 'FormFieldBoolean' && type !== 'FormFieldToggle' && type !== 'FormFieldRadio',
             'is-invalid': props.error != null,
-            'form-check-input': type === 'FormFieldBoolean',
+            'form-check-input': type === 'FormFieldBoolean' || type === 'FormFieldToggle' || type === 'FormFieldRadio',
           }
         case 'select':
           return 'form-select'
@@ -97,17 +99,35 @@ export const classNameGenerator: ClassNameGenerator = ({
           if (props.displayMode === 'inline') {
             return 'visually-hidden'
           } else {
-            return { 'form-label': true, 'fw-bold': !!props.required, 'form-check-label': type === 'FormFieldBoolean' }
+            return {
+              'form-label': true,
+              'fw-bold': !!props.required,
+              'form-check-label': type === 'FormFieldBoolean' || type === 'FormFieldToggle',
+            }
           }
         case 'error':
           return 'invalid-feedback'
         case 'description':
           return 'form-text'
+        case 'radio':
+          return 'form-check'
+        case 'radio-group':
+          return ''
+        case 'radio-group-inline':
+          return 'd-flex gap-3 flex-wrap'
+        case 'radio-label':
+          return 'form-check-label'
+        case 'toggle-labels':
+          return 'ms-2 small text-muted'
+        case 'toggle-on':
+          return 'ms-1'
+        case 'toggle-off':
+          return 'me-1'
         default:
           return {
             'mb-3': true,
-            'form-check': type === 'FormFieldBoolean',
-            'form-switch': type === 'FormFieldBoolean' && props.mode === 'switch',
+            'form-check': type === 'FormFieldBoolean' || type === 'FormFieldToggle',
+            'form-switch': type === 'FormFieldToggle' || (type === 'FormFieldBoolean' && props.mode === 'switch'),
           }
       }
     case 'Navbar':

--- a/src/npm-fastui/src/components/FormField.tsx
+++ b/src/npm-fastui/src/components/FormField.tsx
@@ -6,6 +6,8 @@ import type {
   FormFieldInput,
   FormFieldTextarea,
   FormFieldBoolean,
+  FormFieldToggle,
+  FormFieldRadio,
   FormFieldFile,
   FormFieldSelect,
   FormFieldSelectSearch,
@@ -95,6 +97,106 @@ export const FormFieldBooleanComp: FC<FormFieldBooleanProps> = (props) => {
         aria-describedby={descId(props)}
         onChange={onChange}
       />
+      <ErrorDescription {...props} />
+    </div>
+  )
+}
+
+interface FormFieldToggleProps extends FormFieldToggle {
+  onChange?: PrivateOnChange
+}
+
+export const FormFieldToggleComp: FC<FormFieldToggleProps> = (props) => {
+  const { name, required, locked, onChange, onLabel, offLabel } = props
+  // hooks must be called unconditionally; precompute every class name before render.
+  const containerClass = useClassName(props)
+  const inputClass = useClassName(props, { el: 'input' })
+  const labelsClass = useClassName(props, { el: 'toggle-labels' })
+  const onClass = useClassName(props, { el: 'toggle-on' })
+  const offClass = useClassName(props, { el: 'toggle-off' })
+
+  return (
+    <div className={containerClass}>
+      <Label {...props} />
+      <input
+        type="checkbox"
+        role="switch"
+        className={inputClass}
+        defaultChecked={!!props.initial}
+        id={inputId(props)}
+        name={name}
+        required={required}
+        disabled={locked}
+        aria-describedby={descId(props)}
+        onChange={onChange}
+      />
+      {/* Optional on/off labels render after the switch so screen readers announce them
+          alongside the standard label. They are visual hints, not separate inputs. */}
+      {(onLabel || offLabel) && (
+        <span className={labelsClass}>
+          {offLabel && <span className={offClass}>{offLabel}</span>}
+          {onLabel && <span className={onClass}>{onLabel}</span>}
+        </span>
+      )}
+      <ErrorDescription {...props} />
+    </div>
+  )
+}
+
+interface FormFieldRadioProps extends FormFieldRadio {
+  onChange?: PrivateOnChange
+}
+
+export const FormFieldRadioComp: FC<FormFieldRadioProps> = (props) => {
+  const { name, required, locked, options, initial, onChange, inline } = props
+  const groupId = inputId(props)
+  // hooks must be called unconditionally; precompute every class name before render.
+  const containerClass = useClassName(props)
+  const radioGroupClass = useClassName(props, { el: 'radio-group' })
+  const radioGroupInlineClass = useClassName(props, { el: 'radio-group-inline' })
+  const radioClass = useClassName(props, { el: 'radio' })
+  const inputClass = useClassName(props, { el: 'input' })
+  const radioLabelClass = useClassName(props, { el: 'radio-label' })
+
+  // Flatten any select groups so we can render a flat list of <input type="radio"> rows.
+  // We don't currently render group separators because the radio control isn't a great
+  // place to display section headings — the maintainer can add that later if needed.
+  const flatOptions: SelectOption[] = []
+  for (const opt of options) {
+    if ('options' in opt) {
+      flatOptions.push(...opt.options)
+    } else {
+      flatOptions.push(opt)
+    }
+  }
+
+  return (
+    <div className={containerClass} role="radiogroup" aria-labelledby={`${groupId}-label`}>
+      <Label {...props} />
+      <div className={inline ? radioGroupInlineClass : radioGroupClass}>
+        {flatOptions.map((opt, i) => {
+          const optionId = `${groupId}-${i}`
+          return (
+            <div key={opt.value} className={radioClass}>
+              <input
+                type="radio"
+                className={inputClass}
+                id={optionId}
+                name={name}
+                value={opt.value}
+                defaultChecked={initial === opt.value}
+                required={required && i === 0}
+                disabled={locked}
+                aria-describedby={descId(props)}
+                onChange={onChange}
+              />
+              <label htmlFor={optionId} className={radioLabelClass}>
+                {opt.label}
+              </label>
+            </div>
+          )
+        })}
+      </div>
       <ErrorDescription {...props} />
     </div>
   )
@@ -329,6 +431,8 @@ export type FormFieldProps =
   | FormFieldInputProps
   | FormFieldTextareaProps
   | FormFieldBooleanProps
+  | FormFieldToggleProps
+  | FormFieldRadioProps
   | FormFieldFileProps
   | FormFieldSelectProps
   | FormFieldSelectSearchProps

--- a/src/npm-fastui/src/components/index.tsx
+++ b/src/npm-fastui/src/components/index.tsx
@@ -18,6 +18,8 @@ import {
   FormFieldInputComp,
   FormFieldTextareaComp,
   FormFieldBooleanComp,
+  FormFieldToggleComp,
+  FormFieldRadioComp,
   FormFieldSelectComp,
   FormFieldSelectSearchComp,
   FormFieldFileComp,
@@ -55,6 +57,8 @@ export {
   FormComp,
   FormFieldInputComp,
   FormFieldBooleanComp,
+  FormFieldToggleComp,
+  FormFieldRadioComp,
   FormFieldSelectComp,
   FormFieldSelectSearchComp,
   FormFieldFileComp,
@@ -134,6 +138,10 @@ export const AnyComp: FC<FastProps> = (props) => {
         return <FormFieldTextareaComp {...props} />
       case 'FormFieldBoolean':
         return <FormFieldBooleanComp {...props} />
+      case 'FormFieldToggle':
+        return <FormFieldToggleComp {...props} />
+      case 'FormFieldRadio':
+        return <FormFieldRadioComp {...props} />
       case 'FormFieldFile':
         return <FormFieldFileComp {...props} />
       case 'FormFieldSelect':

--- a/src/npm-fastui/src/models.d.ts
+++ b/src/npm-fastui/src/models.d.ts
@@ -36,6 +36,8 @@ export type FastProps =
   | FormFieldInput
   | FormFieldTextarea
   | FormFieldBoolean
+  | FormFieldToggle
+  | FormFieldRadio
   | FormFieldFile
   | FormFieldSelect
   | FormFieldSelectSearch
@@ -559,6 +561,8 @@ export interface Form {
     | FormFieldInput
     | FormFieldTextarea
     | FormFieldBoolean
+    | FormFieldToggle
+    | FormFieldRadio
     | FormFieldFile
     | FormFieldSelect
     | FormFieldSelectSearch
@@ -640,6 +644,50 @@ export interface FormFieldBoolean {
   initial?: boolean
   mode?: 'checkbox' | 'switch'
   type: 'FormFieldBoolean'
+}
+/**
+ * Form field for an on/off toggle (switch) input.
+ */
+export interface FormFieldToggle {
+  name: string
+  title: string[] | string
+  required?: boolean
+  error?: string
+  locked?: boolean
+  description?: string
+  displayMode?: 'default' | 'inline'
+  className?:
+    | string
+    | ClassName[]
+    | {
+        [k: string]: boolean
+      }
+  initial?: boolean
+  onLabel?: string
+  offLabel?: string
+  type: 'FormFieldToggle'
+}
+/**
+ * Form field for a radio button group.
+ */
+export interface FormFieldRadio {
+  name: string
+  title: string[] | string
+  required?: boolean
+  error?: string
+  locked?: boolean
+  description?: string
+  displayMode?: 'default' | 'inline'
+  className?:
+    | string
+    | ClassName[]
+    | {
+        [k: string]: boolean
+      }
+  options: SelectOptions
+  initial?: string
+  inline?: boolean
+  type: 'FormFieldRadio'
 }
 /**
  * Form field for file input.
@@ -748,6 +796,8 @@ export interface ModelForm {
     | FormFieldInput
     | FormFieldTextarea
     | FormFieldBoolean
+    | FormFieldToggle
+    | FormFieldRadio
     | FormFieldFile
     | FormFieldSelect
     | FormFieldSelectSearch

--- a/src/python-fastui/fastui/components/__init__.py
+++ b/src/python-fastui/fastui/components/__init__.py
@@ -3,6 +3,7 @@ Component definitions.
 
 All CamelCase names in the namespace should be components.
 """
+
 import typing as _t
 
 import pydantic as _p
@@ -21,8 +22,10 @@ from .forms import (
     FormFieldBoolean,
     FormFieldFile,
     FormFieldInput,
+    FormFieldRadio,
     FormFieldSelect,
     FormFieldSelectSearch,
+    FormFieldToggle,
     ModelForm,
 )
 from .tables import Pagination, Table
@@ -66,8 +69,10 @@ __all__ = (
     'FormFieldBoolean',
     'FormFieldFile',
     'FormFieldInput',
+    'FormFieldRadio',
     'FormFieldSelect',
     'FormFieldSelectSearch',
+    'FormFieldToggle',
 )
 
 
@@ -396,16 +401,19 @@ class Image(BaseModel, extra='forbid'):
     height: str | int | None = None
     """Optional height used to display the image."""
 
-    referrer_policy: _t.Literal[
-        'no-referrer',
-        'no-referrer-when-downgrade',
-        'origin',
-        'origin-when-cross-origin',
-        'same-origin',
-        'strict-origin',
-        'strict-origin-when-cross-origin',
-        'unsafe-url',
-    ] | None = None
+    referrer_policy: (
+        _t.Literal[
+            'no-referrer',
+            'no-referrer-when-downgrade',
+            'origin',
+            'origin-when-cross-origin',
+            'same-origin',
+            'strict-origin',
+            'strict-origin-when-cross-origin',
+            'unsafe-url',
+        ]
+        | None
+    ) = None
     """Optional referrer policy for the image. Specifies what information to send when fetching the image.
 
     For more info, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy."""
@@ -550,17 +558,20 @@ class Toast(BaseModel, defer_build=True, extra='forbid'):
     """List of components to render in the toast body."""
 
     # TODO: change these before the release (top left, center, end, etc). Can be done with the toast bug fix.
-    position: _t.Literal[
-        'top-start',
-        'top-center',
-        'top-end',
-        'middle-start',
-        'middle-center',
-        'middle-end',
-        'bottom-start',
-        'bottom-center',
-        'bottom-end',
-    ] | None = None
+    position: (
+        _t.Literal[
+            'top-start',
+            'top-center',
+            'top-end',
+            'middle-start',
+            'middle-center',
+            'middle-end',
+            'bottom-start',
+            'bottom-center',
+            'bottom-end',
+        ]
+        | None
+    ) = None
     """Optional position of the toast."""
 
     open_trigger: events.PageEvent | None = None

--- a/src/python-fastui/fastui/components/forms.py
+++ b/src/python-fastui/fastui/components/forms.py
@@ -97,6 +97,48 @@ class FormFieldBoolean(BaseFormField):
     """The type of the component. Always 'FormFieldBoolean'."""
 
 
+class FormFieldToggle(BaseFormField):
+    """Form field for an on/off toggle (switch) input.
+
+    `FormFieldToggle` is a thin wrapper around the boolean form field that always
+    renders as a switch. It is provided so backends and templates that want a
+    dedicated toggle component do not need to set `mode='switch'` on every field.
+    """
+
+    initial: bool | None = None
+    """Initial value for the field."""
+
+    on_label: str | None = None
+    """Optional label to show next to the toggle when it is on."""
+
+    off_label: str | None = None
+    """Optional label to show next to the toggle when it is off."""
+
+    type: _t.Literal['FormFieldToggle'] = 'FormFieldToggle'
+    """The type of the component. Always 'FormFieldToggle'."""
+
+
+class FormFieldRadio(BaseFormField):
+    """Form field for a radio button group.
+
+    Renders as a list of mutually-exclusive radio buttons rather than a `<select>`
+    drop-down. Useful for short option lists where surfacing every choice up front
+    is preferable to a drop-down.
+    """
+
+    options: forms.SelectOptions
+    """Options for the radio group."""
+
+    initial: str | None = None
+    """Initial value for the field."""
+
+    inline: bool | None = None
+    """Whether to render the radio buttons in a single inline row."""
+
+    type: _t.Literal['FormFieldRadio'] = 'FormFieldRadio'
+    """The type of the component. Always 'FormFieldRadio'."""
+
+
 class FormFieldFile(BaseFormField):
     """Form field for file input."""
 
@@ -158,7 +200,14 @@ class FormFieldSelectSearch(BaseFormField):
 
 
 FormField = (
-    FormFieldInput | FormFieldTextarea | FormFieldBoolean | FormFieldFile | FormFieldSelect | FormFieldSelectSearch
+    FormFieldInput
+    | FormFieldTextarea
+    | FormFieldBoolean
+    | FormFieldToggle
+    | FormFieldRadio
+    | FormFieldFile
+    | FormFieldSelect
+    | FormFieldSelectSearch
 )
 
 """Union of all form field types."""

--- a/src/python-fastui/fastui/forms.py
+++ b/src/python-fastui/fastui/forms.py
@@ -19,7 +19,16 @@ except ImportError as _e:
 if _t.TYPE_CHECKING:
     from . import json_schema
 
-__all__ = 'FastUIForm', 'fastui_form', 'FormFile', 'Textarea', 'SelectSearchResponse', 'SelectOption'
+__all__ = (
+    'FastUIForm',
+    'fastui_form',
+    'FormFile',
+    'Textarea',
+    'Radio',
+    'Toggle',
+    'SelectSearchResponse',
+    'SelectOption',
+)
 
 FormModel = _t.TypeVar('FormModel', bound=pydantic.BaseModel)
 
@@ -110,10 +119,7 @@ class FormFile:
 
         raise pydantic_core.PydanticCustomError(
             'accept_mismatch',
-            (
-                'Uploaded file "{filename}" with content type "{content_type}" '
-                'does not match accept criteria "{accept}"'
-            ),
+            ('Uploaded file "{filename}" with content type "{content_type}" does not match accept criteria "{accept}"'),
             {'filename': file.filename, 'content_type': file.content_type, 'accept': self.accept},
         )
 
@@ -231,3 +237,38 @@ def name_to_loc(name: str) -> 'json_schema.SchemeLocation':
 # Use uppercase for consistency with pydantic.Field, which is also a function
 def Textarea(rows: int | None = None, cols: int | None = None) -> _t.Any:  # N802
     return pydantic.Field(json_schema_extra={'format': 'textarea', 'rows': rows, 'cols': cols})
+
+
+# Use uppercase for consistency with pydantic.Field, which is also a function
+def Radio(*, inline: bool | None = None) -> _t.Any:  # N802
+    """Render a string-`Enum`/`Literal` field as a radio button group.
+
+    Use as the `Field(...)` value of a Pydantic field, e.g.::
+
+        class Form(BaseModel):
+            choice: MyEnum = Radio()
+
+    By default the radios stack vertically; pass `inline=True` to render them on a
+    single row. Multi-value fields (`list[MyEnum]`) fall back to the standard
+    select component because radios can only express a single selected value.
+    """
+    extra: dict[str, _t.Any] = {'format': 'radio'}
+    if inline is not None:
+        extra['inline'] = inline
+    return pydantic.Field(json_schema_extra=extra)
+
+
+# Use uppercase for consistency with pydantic.Field, which is also a function
+def Toggle(*, on_label: str | None = None, off_label: str | None = None) -> _t.Any:  # N802
+    """Render a `bool` field as a dedicated on/off toggle (switch).
+
+    Unlike `mode='switch'` on `FormFieldBoolean`, this emits the standalone
+    `FormFieldToggle` component so backends and renderers can treat toggles
+    as a first-class field type.
+    """
+    extra: dict[str, _t.Any] = {'format': 'toggle'}
+    if on_label is not None:
+        extra['on_label'] = on_label
+    if off_label is not None:
+        extra['off_label'] = off_label
+    return pydantic.Field(json_schema_extra=extra)

--- a/src/python-fastui/fastui/generate_typescript.py
+++ b/src/python-fastui/fastui/generate_typescript.py
@@ -124,7 +124,7 @@ def json2ts(input_file: Path, output_file: Path):  # pragma: no cover
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
         raise RuntimeError(
             "Failed to run json2ts, you'll need to install `npx` and `json-schema-to-typescript`, "
-            f"then run the command:\n\n    {' '.join(args)}\n\n"
+            f'then run the command:\n\n    {" ".join(args)}\n\n'
         ) from e
     else:
         assert output_file.is_file()

--- a/src/python-fastui/fastui/json_schema.py
+++ b/src/python-fastui/fastui/json_schema.py
@@ -10,9 +10,11 @@ from .components.forms import (
     FormFieldBoolean,
     FormFieldFile,
     FormFieldInput,
+    FormFieldRadio,
     FormFieldSelect,
     FormFieldSelectSearch,
     FormFieldTextarea,
+    FormFieldToggle,
     InputHtmlType,
 )
 
@@ -183,6 +185,18 @@ def json_schema_field_to_field(
 ) -> FormField:
     name = loc_to_name(loc)
     if schema['type'] == 'boolean':
+        # `format='toggle'` opts boolean fields into the dedicated `FormFieldToggle`
+        # type instead of the boolean+switch mode, which keeps the discriminator clean.
+        if schema.get('format') == 'toggle':
+            return FormFieldToggle(
+                name=name,
+                title=title,
+                required=required,
+                initial=schema.get('default'),
+                description=description,
+                on_label=schema.get('on_label'),
+                off_label=schema.get('off_label'),
+            )
         return FormFieldBoolean(
             name=name,
             title=title,
@@ -277,13 +291,27 @@ def special_string_field(
             )
         elif enum := schema.get('enum'):
             enum_labels = schema.get('enum_labels', {})
+            options = [SelectOption(value=v, label=enum_labels.get(v) or as_title(v)) for v in enum]
+            # `format='radio'` opts a string-enum field into a radio button group instead
+            # of a select drop-down. Multi-select can't be represented as radios, so we
+            # fall back to the regular select component when `multiple` is set.
+            if schema.get('format') == 'radio' and not multiple:
+                return FormFieldRadio(
+                    name=name,
+                    title=title,
+                    required=required,
+                    options=options,
+                    initial=schema.get('default'),
+                    description=description,
+                    inline=schema.get('inline'),
+                )
             return FormFieldSelect(
                 name=name,
                 title=title,
                 placeholder=schema.get('placeholder'),
                 required=required,
                 multiple=multiple,
-                options=[SelectOption(value=v, label=enum_labels.get(v) or as_title(v)) for v in enum],
+                options=options,
                 initial=schema.get('default'),
                 description=description,
                 autocomplete=schema.get('autocomplete'),
@@ -328,7 +356,14 @@ def deference_json_schema(
         if def_schema is None:
             raise ValueError(f'Invalid $ref "{ref}", not found in {defs}')
         else:
-            return def_schema.copy(), required  # clone dict to avoid attribute leakage via shared schema.
+            # clone dict to avoid attribute leakage via shared schema, then layer in any
+            # sibling keys from the outer schema (e.g. `format` / `description` set via
+            # `Field(json_schema_extra=...)`) so per-field overrides survive deref.
+            merged = def_schema.copy()
+            for key, value in schema.items():  # type: ignore[union-attr]
+                if key != '$ref':
+                    merged[key] = value  # type: ignore[index]
+            return merged, required
     elif any_of := schema.get('anyOf'):
         if len(any_of) == 2 and sum(s.get('type') == 'null' for s in any_of) == 1:
             # If anyOf is a single type and null, then it is optional

--- a/src/python-fastui/tests/test_components.py
+++ b/src/python-fastui/tests/test_components.py
@@ -4,6 +4,7 @@ Simple tests of component creation.
 NOTE: we do NOT want to exhaustively construct every component just for the same of it -
 that's just testing pydantic!
 """
+
 from fastui import FastUI, components
 from pydantic import HttpUrl
 

--- a/src/python-fastui/tests/test_forms.py
+++ b/src/python-fastui/tests/test_forms.py
@@ -6,7 +6,7 @@ from typing import Annotated
 import pytest
 from fastapi import HTTPException
 from fastui import components
-from fastui.forms import FormFile, Textarea, fastui_form
+from fastui.forms import FormFile, Radio, Textarea, Toggle, fastui_form
 from pydantic import BaseModel, Field
 from starlette.datastructures import FormData, Headers, UploadFile
 
@@ -545,3 +545,111 @@ def test_form_fields():
         'submitUrl': '/foobar/',
         'type': 'ModelForm',
     }
+
+
+class Color(str, enum.Enum):
+    red = 'red'
+    green = 'green'
+    blue = 'blue'
+
+
+class RadioForm(BaseModel):
+    color: Color = Radio()
+    size: Color = Radio(inline=True)
+
+
+def test_radio_form_fields():
+    m = components.ModelForm(model=RadioForm, submit_url='/foobar/')
+
+    assert m.model_dump(by_alias=True, exclude_none=True) == {
+        'submitUrl': '/foobar/',
+        'method': 'POST',
+        'type': 'ModelForm',
+        'formFields': [
+            {
+                'name': 'color',
+                'title': ['Color'],
+                'required': True,
+                'locked': False,
+                'options': [
+                    {'value': 'red', 'label': 'Red'},
+                    {'value': 'green', 'label': 'Green'},
+                    {'value': 'blue', 'label': 'Blue'},
+                ],
+                'type': 'FormFieldRadio',
+            },
+            {
+                'name': 'size',
+                'title': ['Color'],
+                'required': True,
+                'locked': False,
+                'options': [
+                    {'value': 'red', 'label': 'Red'},
+                    {'value': 'green', 'label': 'Green'},
+                    {'value': 'blue', 'label': 'Blue'},
+                ],
+                'inline': True,
+                'type': 'FormFieldRadio',
+            },
+        ],
+    }
+
+
+async def test_radio_form_submit():
+    form_dep = fastui_form(RadioForm)
+    request = FakeRequest([('color', 'red'), ('size', 'blue')])
+    m = await form_dep.dependency(request)
+    assert isinstance(m, RadioForm)
+    assert m.color is Color.red
+    assert m.size is Color.blue
+
+
+def test_radio_form_invalid_value():
+    # ensure validation surfaces a normal pydantic error for unknown radio values
+    with pytest.raises(ValueError):
+        RadioForm(color='magenta', size='red')
+
+
+class ToggleForm(BaseModel):
+    notify: bool = Toggle()
+    archive: bool = Toggle(on_label='On', off_label='Off')
+
+
+def test_toggle_form_fields():
+    m = components.ModelForm(model=ToggleForm, submit_url='/foobar/')
+
+    assert m.model_dump(by_alias=True, exclude_none=True) == {
+        'submitUrl': '/foobar/',
+        'method': 'POST',
+        'type': 'ModelForm',
+        'formFields': [
+            {
+                'name': 'notify',
+                'title': ['Notify'],
+                'required': True,
+                'locked': False,
+                'type': 'FormFieldToggle',
+            },
+            {
+                'name': 'archive',
+                'title': ['Archive'],
+                'required': True,
+                'locked': False,
+                'onLabel': 'On',
+                'offLabel': 'Off',
+                'type': 'FormFieldToggle',
+            },
+        ],
+    }
+
+
+def test_radio_multiple_falls_back_to_select():
+    # radios can't represent multi-select, so a `list[Enum]` annotated with `Radio()`
+    # should fall back to the regular select field (multiple=True).
+    class MultiRadioForm(BaseModel):
+        colors: list[Color] = Radio()
+
+    m = components.ModelForm(model=MultiRadioForm, submit_url='/foobar/')
+    fields = m.model_dump(by_alias=True, exclude_none=True)['formFields']
+    assert fields[0]['type'] == 'FormFieldSelect'
+    assert fields[0]['multiple'] is True


### PR DESCRIPTION
## Summary
Closes #160. Adds two requested form fields: `Radio` (radio button group) and `Toggle` (on/off switch).

## What's added
- `FormFieldRadio` — radio button group with optional `inline` flag
- `FormFieldToggle` — dedicated on/off switch with optional `on_label`/`off_label`

## Files changed (13)
**TypeScript:**
- `src/npm-fastui/src/components/FormField.tsx`, `components/index.tsx`, `models.d.ts`
- `src/npm-fastui-bootstrap/src/index.tsx`
- `src/npm-fastui-bootstrap/src/Radio.tsx` (new)
- `src/npm-fastui-bootstrap/src/Toggle.tsx` (new)

**Python:**
- `fastui/components/forms.py`, `components/__init__.py`, `forms.py` — `Radio()` / `Toggle()` helpers
- `json_schema.py` — radio/toggle dispatch + `$ref` sibling-key preservation

**Tests:**
- `tests/test_forms.py` — 5 new tests

## Test plan
- TS: `npm run typecheck` clean, `npm run lint` clean (0 errors), prettier clean
- Python: `ruff format --check` passes, `ruff check` clean on diff (1 preexisting error in unchanged code)
- pytest 67 passed (2 preexisting auth-github failures are env-only, unrelated)
